### PR TITLE
Changing working and workspace directory management

### DIFF
--- a/pythonVLM/VLM_utilities.py
+++ b/pythonVLM/VLM_utilities.py
@@ -19,11 +19,11 @@ def create_workspace(name, origin):
     import os
     from distutils import dir_util
 
-    temp_dir = os.path.join(os.path.split(__file__)[0], "..")
-    vlm_dir = os.path.abspath(temp_dir)
-    work_dir = origin.replace(os.sep, "_")
-    workspace = os.path.join(vlm_dir, "workspace", work_dir)
-    origin_models = os.path.join(vlm_dir, origin, "models")
+    cur_dir = os.getcwd()
+    work_dir = name.replace(os.sep, "_")
+    work_dir = work_dir.replace(".", "_")
+    workspace = os.path.join(cur_dir, "workspace", work_dir)
+    origin_models = os.path.join(cur_dir, origin, "models")
     models = os.path.join(workspace, "models")
     if not os.path.exists(models):
         os.makedirs(models)
@@ -32,10 +32,14 @@ def create_workspace(name, origin):
     os.chdir(workspace)
     return workspace
 
-def add_path(name):
+def add_path(name, usecurdir = False):
     import os, sys
-    vlm_dir = os.path.abspath(os.path.split(__file__)[0])
-    path = os.path.join(vlm_dir, "..", "..", name)
+    if usecurdir:   # Uses current path
+        curdir = os.getcwd()
+        path = os.path.join(curdir, name)
+    else:           # Uses relative path from VLM directory
+        vlm_dir = os.path.abspath(os.path.split(__file__)[0])
+        path = os.path.join(vlm_dir, "..", "..", name)
     if os.path.isdir(path):
          print(("INFO: adding {} to PYTHONPATH".format(path)))
          sys.path.append(path)

--- a/run.py
+++ b/run.py
@@ -26,21 +26,21 @@ def main():
     args = parser.parse_args()
 
 
-    vlm_dir = os.path.abspath(os.path.split(__file__)[0])
+    orig_dir = os.getcwd()                              # Initial working directory
 
     names = args.file[0].split(os.sep)
-    filename = names[-1]
-    name = names[-2]
-    origin = os.path.split(args.file[0])[0]
+    filename = names[-1]                                # Filename of the test case, usually ending on .py
+    origin = os.path.split(args.file[0])[0]             # Path from the working directory to the file
+    workspace_name = os.path.splitext(args.file[0])[0]  # Workspace name including filename but not .py
 
-    utils.add_path(os.path.join("VLM", origin))
+    utils.add_path(origin, True)
 
-    workspace = utils.create_workspace(name, origin)
+    workspace = utils.create_workspace(workspace_name, origin)
     print(("Workspace: {}".format(workspace)))
 
     
 
-    filename = os.path.join(vlm_dir, origin, filename)
+    filename = os.path.join(orig_dir, origin, filename) # Absolute path to the file
     if os.path.isfile(filename):
         print(("Executing file {}".format(filename)))
         exec(compile(open(filename, "rb").read(), filename, 'exec'), globals(), locals())


### PR DESCRIPTION
This small PR should solve issue #7. It changes how the working directory is managed and is no longer assumed to be within the VLM repository. Furthermore, it adds the name of the script to the workspace folder so that results are not overwritten if there are two scripts in the same folder.

So, if folder `aircraft` has two scripts `aircraft1.py` and `aircraft2.py`, the code will create a `workspace/aircraft_aircraft1` folder when running the first case and `workspace/aircraft_aircraft2` when running the second. Both these folders will be within the current working directory.
